### PR TITLE
카테고리 관리 기본 기능

### DIFF
--- a/src/main/java/site/caboomlog/backendservice/blogmember/repository/BlogMemberMappingRepository.java
+++ b/src/main/java/site/caboomlog/backendservice/blogmember/repository/BlogMemberMappingRepository.java
@@ -1,6 +1,7 @@
 package site.caboomlog.backendservice.blogmember.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import site.caboomlog.backendservice.blogmember.entity.BlogMemberMapping;
 
 import java.util.List;
@@ -10,6 +11,7 @@ public interface BlogMemberMappingRepository extends JpaRepository<BlogMemberMap
 
     boolean existsByMember_MbNoAndBlog_BlogFid(Long mbNo, String blogFid);
 
+    @Query("SELECT m FROM BlogMemberMapping m JOIN FETCH m.blog WHERE m.member.mbNo = ?1 AND m.blog.blogFid = ?2")
     BlogMemberMapping findByMember_MbNoAndBlog_BlogFid(Long mbNo, String blogFid);
 
     BlogMemberMapping findByMember_MbUuidAndBlog_BlogFid(String mbUuid, String blogFid);

--- a/src/main/java/site/caboomlog/backendservice/category/advice/CategoryControllerAdvice.java
+++ b/src/main/java/site/caboomlog/backendservice/category/advice/CategoryControllerAdvice.java
@@ -1,0 +1,19 @@
+package site.caboomlog.backendservice.category.advice;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import site.caboomlog.backendservice.category.exception.CategoryNotFoundException;
+import site.caboomlog.backendservice.common.dto.ApiResponse;
+
+@Slf4j
+@RestControllerAdvice
+public class CategoryControllerAdvice {
+    @ExceptionHandler(CategoryNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCategoryNotFoundException(CategoryNotFoundException e) {
+        log.info("handleCategoryNotFoundException - ", e);
+        return ResponseEntity.status(404)
+                .body(ApiResponse.notFound(e.getMessage()));
+    }
+}

--- a/src/main/java/site/caboomlog/backendservice/category/controller/CategoryController.java
+++ b/src/main/java/site/caboomlog/backendservice/category/controller/CategoryController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.caboomlog.backendservice.category.dto.CategoryResponse;
+import site.caboomlog.backendservice.category.dto.ChangeVisibilityRequest;
 import site.caboomlog.backendservice.category.dto.CreateCategoryRequest;
 import site.caboomlog.backendservice.category.service.CategoryService;
 import site.caboomlog.backendservice.common.annotation.LoginMember;
@@ -63,5 +64,28 @@ public class CategoryController {
                                                                                           String blogFid) {
         List<CategoryResponse> categories = categoryService.getAllPublicCategories(blogFid);
         return ResponseEntity.ok(ApiResponse.ok(categories));
+    }
+
+    /**
+     * 카테고리 공개 여부를 변경합니다.
+     * <p>
+     * 공개 상태를 비공개로 변경할 경우, 해당 카테고리의 하위 카테고리들도 모두 비공개로 변경됩니다.
+     * 공개로 전환할 경우, 해당 카테고리만 공개로 변경됩니다.
+     * </p>
+     *
+     * @param blogFid     블로그 식별자
+     * @param categoryId  카테고리 ID
+     * @param ownerMbNo   로그인한 사용자(블로그 소유자)의 회원 번호
+     * @param request     공개 여부 변경 요청 객체
+     * @return 상태 200 OK 응답
+     */
+    @PostMapping("/{categoryId}/public")
+    public ResponseEntity<ApiResponse<Void>> changeVisibility(@PathVariable("blogFid") String blogFid,
+                                                              @PathVariable("categoryId") Long categoryId,
+                                                              @LoginMember Long ownerMbNo,
+                                                              @RequestBody ChangeVisibilityRequest request) {
+        categoryService.changeVisibility(ownerMbNo, blogFid, categoryId, request.isBlogPublic());
+        return ResponseEntity.ok()
+                .body(ApiResponse.ok(null));
     }
 }

--- a/src/main/java/site/caboomlog/backendservice/category/controller/CategoryController.java
+++ b/src/main/java/site/caboomlog/backendservice/category/controller/CategoryController.java
@@ -1,0 +1,26 @@
+package site.caboomlog.backendservice.category.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import site.caboomlog.backendservice.category.dto.CreateCategoryRequest;
+import site.caboomlog.backendservice.category.service.CategoryService;
+import site.caboomlog.backendservice.common.annotation.LoginMember;
+import site.caboomlog.backendservice.common.dto.ApiResponse;
+
+@RestController
+@RequestMapping("/api/blogs/{blogFid}/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createCategory(@PathVariable("blogFid") String blogFid,
+                                                      @LoginMember Long mbNo,
+                                                      @RequestBody CreateCategoryRequest request) {
+        categoryService.createCategory(blogFid, mbNo, request);
+        return ResponseEntity.status(201)
+                .body(ApiResponse.created());
+    }
+}

--- a/src/main/java/site/caboomlog/backendservice/category/controller/CategoryController.java
+++ b/src/main/java/site/caboomlog/backendservice/category/controller/CategoryController.java
@@ -84,7 +84,7 @@ public class CategoryController {
                                                               @PathVariable("categoryId") Long categoryId,
                                                               @LoginMember Long ownerMbNo,
                                                               @RequestBody ChangeVisibilityRequest request) {
-        categoryService.changeVisibility(ownerMbNo, blogFid, categoryId, request.isBlogPublic());
+        categoryService.changeVisibility(ownerMbNo, blogFid, categoryId, request.isCategoryPublic());
         return ResponseEntity.ok()
                 .body(ApiResponse.ok(null));
     }

--- a/src/main/java/site/caboomlog/backendservice/category/controller/CategoryController.java
+++ b/src/main/java/site/caboomlog/backendservice/category/controller/CategoryController.java
@@ -3,10 +3,13 @@ package site.caboomlog.backendservice.category.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import site.caboomlog.backendservice.category.dto.CategoryResponse;
 import site.caboomlog.backendservice.category.dto.CreateCategoryRequest;
 import site.caboomlog.backendservice.category.service.CategoryService;
 import site.caboomlog.backendservice.common.annotation.LoginMember;
 import site.caboomlog.backendservice.common.dto.ApiResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/blogs/{blogFid}/categories")
@@ -15,6 +18,14 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
+    /**
+     * 블로그에 새로운 카테고리를 생성합니다.
+     *
+     * @param blogFid 블로그 고유 식별자
+     * @param mbNo 로그인한 사용자(블로그 소유자)의 회원 번호 (AOP로 주입됨)
+     * @param request 카테고리 생성 요청 본문
+     * @return 생성 완료 응답 (HTTP 201 Created)
+     */
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createCategory(@PathVariable("blogFid") String blogFid,
                                                       @LoginMember Long mbNo,
@@ -22,5 +33,35 @@ public class CategoryController {
         categoryService.createCategory(blogFid, mbNo, request);
         return ResponseEntity.status(201)
                 .body(ApiResponse.created());
+    }
+
+    /**
+     * 블로그의 전체 카테고리 목록을 트리 형태로 조회합니다.
+     * 이 API는 인증이 필요하며, 블로그 소유자만 호출할 수 있습니다.
+     *
+     * @param blogFid 블로그 고유 식별자
+     * @param mbNo 로그인한 사용자의 회원 번호 (AOP로 주입됨)
+     * @return 트리 형태의 카테고리 목록
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CategoryResponse>>> getAllCategories(@PathVariable("blogFid")
+                                                                                    String blogFid,
+                                                                                @LoginMember Long mbNo) {
+        List<CategoryResponse> categories = categoryService.getCategories(blogFid, mbNo);
+        return ResponseEntity.ok(ApiResponse.ok(categories));
+    }
+
+    /**
+     * 블로그의 공개된 카테고리 목록을 트리 형태로 조회합니다.
+     * 이 API는 인증이 필요하지 않으며, 누구나 접근 가능합니다.
+     *
+     * @param blogFid 블로그 고유 식별자
+     * @return 트리 형태의 공개 카테고리 목록
+     */
+    @GetMapping("/public")
+    public ResponseEntity<ApiResponse<List<CategoryResponse>>> getAllPublicCategories(@PathVariable("blogFid")
+                                                                                          String blogFid) {
+        List<CategoryResponse> categories = categoryService.getAllPublicCategories(blogFid);
+        return ResponseEntity.ok(ApiResponse.ok(categories));
     }
 }

--- a/src/main/java/site/caboomlog/backendservice/category/controller/CategoryController.java
+++ b/src/main/java/site/caboomlog/backendservice/category/controller/CategoryController.java
@@ -6,9 +6,11 @@ import org.springframework.web.bind.annotation.*;
 import site.caboomlog.backendservice.category.dto.CategoryResponse;
 import site.caboomlog.backendservice.category.dto.ChangeVisibilityRequest;
 import site.caboomlog.backendservice.category.dto.CreateCategoryRequest;
+import site.caboomlog.backendservice.category.dto.SwitchOrderRequest;
 import site.caboomlog.backendservice.category.service.CategoryService;
 import site.caboomlog.backendservice.common.annotation.LoginMember;
 import site.caboomlog.backendservice.common.dto.ApiResponse;
+import site.caboomlog.backendservice.common.exception.BadRequestException;
 
 import java.util.List;
 
@@ -85,6 +87,33 @@ public class CategoryController {
                                                               @LoginMember Long ownerMbNo,
                                                               @RequestBody ChangeVisibilityRequest request) {
         categoryService.changeVisibility(ownerMbNo, blogFid, categoryId, request.isCategoryPublic());
+        return ResponseEntity.ok()
+                .body(ApiResponse.ok(null));
+    }
+
+    /**
+     * 두 카테고리의 정렬 순서를 서로 교환합니다.
+     * <p>
+     * 요청한 사용자가 해당 블로그의 소유자인지 검증하고,
+     * 동일한 깊이(depth)를 가진 두 카테고리의 정렬 순서를 바꿉니다.
+     * </p>
+     *
+     * @param blogFid 블로그 식별자 (PathVariable)
+     * @param ownerMbNo 로그인한 사용자 회원 번호 (LoginMember)
+     * @param request categoryId1과 categoryId2가 포함된 정렬 순서 교환 요청 객체
+     * @return 200 OK 응답
+     * @throws BadRequestException categoryId가 잘못되었거나, 다른 depth의 카테고리일 경우
+     */
+    @PutMapping("/orders")
+    public ResponseEntity<ApiResponse<Void>> switchOrder(@PathVariable("blogFid") String blogFid,
+                                                         @LoginMember Long ownerMbNo,
+                                                         @RequestBody SwitchOrderRequest request) {
+        if (request.getCategoryId1() == null || request.getCategoryId1() < 0 ||
+        request.getCategoryId2() == null || request.getCategoryId2() < 0) {
+            throw new BadRequestException("categoryId가 잘못되었습니다.");
+        }
+        categoryService.switchOrder(blogFid, ownerMbNo,
+                request.getCategoryId1(), request.getCategoryId2());
         return ResponseEntity.ok()
                 .body(ApiResponse.ok(null));
     }

--- a/src/main/java/site/caboomlog/backendservice/category/dto/CategoryResponse.java
+++ b/src/main/java/site/caboomlog/backendservice/category/dto/CategoryResponse.java
@@ -16,7 +16,7 @@ public class CategoryResponse {
     private Long categoryId;
     private String categoryName;
     private Boolean categoryPublic;
-    private Long depth;
+    private Integer depth;
     private String topicName;
     private List<CategoryResponse> children = new ArrayList<>();
 

--- a/src/main/java/site/caboomlog/backendservice/category/dto/CategoryResponse.java
+++ b/src/main/java/site/caboomlog/backendservice/category/dto/CategoryResponse.java
@@ -1,0 +1,30 @@
+package site.caboomlog.backendservice.category.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import site.caboomlog.backendservice.category.entity.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CategoryResponse {
+    private Long categoryId;
+    private String categoryName;
+    private Boolean categoryPublic;
+    private Long depth;
+    private String topicName;
+    private List<CategoryResponse> children = new ArrayList<>();
+
+    public CategoryResponse(Category category) {
+        this.categoryId = category.getCategoryId();
+        this.categoryName = category.getCategoryName();
+        this.categoryPublic = category.getCategoryPublic();
+        this.depth = category.getDepth();
+        this.topicName = category.getTopic().getTopicName();
+    }
+}

--- a/src/main/java/site/caboomlog/backendservice/category/dto/ChangeVisibilityRequest.java
+++ b/src/main/java/site/caboomlog/backendservice/category/dto/ChangeVisibilityRequest.java
@@ -7,5 +7,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ChangeVisibilityRequest {
-    private boolean blogPublic;
+    private boolean categoryPublic;
 }

--- a/src/main/java/site/caboomlog/backendservice/category/dto/ChangeVisibilityRequest.java
+++ b/src/main/java/site/caboomlog/backendservice/category/dto/ChangeVisibilityRequest.java
@@ -1,0 +1,11 @@
+package site.caboomlog.backendservice.category.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ChangeVisibilityRequest {
+    private boolean blogPublic;
+}

--- a/src/main/java/site/caboomlog/backendservice/category/dto/CreateCategoryRequest.java
+++ b/src/main/java/site/caboomlog/backendservice/category/dto/CreateCategoryRequest.java
@@ -1,0 +1,14 @@
+package site.caboomlog.backendservice.category.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateCategoryRequest {
+    private Long categoryPid;
+    private String categoryName;
+    private int topicId;
+    private boolean categoryPublic;
+}

--- a/src/main/java/site/caboomlog/backendservice/category/dto/SwitchOrderRequest.java
+++ b/src/main/java/site/caboomlog/backendservice/category/dto/SwitchOrderRequest.java
@@ -1,0 +1,12 @@
+package site.caboomlog.backendservice.category.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SwitchOrderRequest {
+    Long categoryId1;
+    Long categoryId2;
+}

--- a/src/main/java/site/caboomlog/backendservice/category/entity/Category.java
+++ b/src/main/java/site/caboomlog/backendservice/category/entity/Category.java
@@ -1,0 +1,79 @@
+package site.caboomlog.backendservice.category.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import site.caboomlog.backendservice.blog.entity.Blog;
+import site.caboomlog.backendservice.topic.entity.Topic;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "categories")
+@Getter
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long categoryId;
+
+    @JoinColumn(name = "blog_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Blog blog;
+
+    @JoinColumn(name = "category_pid")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category parentCategory;
+
+    @OneToMany(mappedBy = "parentCategory", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Category> childCategories = new ArrayList<>();
+
+    @JoinColumn(name = "topic_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Topic topic;
+
+    @Column(name = "category_name")
+    private String categoryName;
+
+    @Column(name = "category_public", columnDefinition = "tinyint")
+    private Boolean categoryPublic;
+
+    @Column(name = "category_order")
+    private Long categoryOrder;
+
+    @Column(name = "depth")
+    private Long depth;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    protected Category(){}
+
+    private Category(Long categoryId, Blog blog, Category parentCategory, Topic topic,
+                     String categoryName, Boolean categoryPublic, Long categoryOrder,
+                     Long depth, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.categoryId = categoryId;
+        this.blog = blog;
+        this.parentCategory = parentCategory;
+        this.topic = topic;
+        this.categoryName = categoryName;
+        this.categoryPublic = categoryPublic;
+        this.categoryOrder = categoryOrder;
+        this.depth = depth;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static Category ofNewCategory(Blog blog, Category parentCategory, Topic topic,
+                                         String categoryName, Boolean categoryPublic, Long categoryOrder,
+                                         Long depth) {
+        return new Category(null, blog, parentCategory, topic,
+                categoryName, categoryPublic, categoryOrder, depth, null, null);
+    }
+}

--- a/src/main/java/site/caboomlog/backendservice/category/entity/Category.java
+++ b/src/main/java/site/caboomlog/backendservice/category/entity/Category.java
@@ -41,10 +41,10 @@ public class Category {
     private Boolean categoryPublic;
 
     @Column(name = "category_order")
-    private Long categoryOrder;
+    private Integer categoryOrder;
 
     @Column(name = "depth")
-    private Long depth;
+    private Integer depth;
 
     @Column(name = "created_at")
     @CreationTimestamp
@@ -56,8 +56,8 @@ public class Category {
     protected Category(){}
 
     private Category(Long categoryId, Blog blog, Category parentCategory, Topic topic,
-                     String categoryName, Boolean categoryPublic, Long categoryOrder,
-                     Long depth, LocalDateTime createdAt, LocalDateTime updatedAt) {
+                     String categoryName, Boolean categoryPublic, Integer categoryOrder,
+                     Integer depth, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.categoryId = categoryId;
         this.blog = blog;
         this.parentCategory = parentCategory;
@@ -71,8 +71,8 @@ public class Category {
     }
 
     public static Category ofNewCategory(Blog blog, Category parentCategory, Topic topic,
-                                         String categoryName, Boolean categoryPublic, Long categoryOrder,
-                                         Long depth) {
+                                         String categoryName, Boolean categoryPublic, Integer categoryOrder,
+                                         Integer depth) {
         return new Category(null, blog, parentCategory, topic,
                 categoryName, categoryPublic, categoryOrder, depth, null, null);
     }
@@ -87,7 +87,7 @@ public class Category {
     }
 
     public static void switchOrder(Category category1, Category category2) {
-        long order = category1.getCategoryOrder();
+        int order = category1.getCategoryOrder();
         category1.categoryOrder = category2.getCategoryOrder();
         category2.categoryOrder = order;
     }

--- a/src/main/java/site/caboomlog/backendservice/category/entity/Category.java
+++ b/src/main/java/site/caboomlog/backendservice/category/entity/Category.java
@@ -76,4 +76,19 @@ public class Category {
         return new Category(null, blog, parentCategory, topic,
                 categoryName, categoryPublic, categoryOrder, depth, null, null);
     }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void changeVisibility(boolean categoryPublic) {
+        this.categoryPublic = categoryPublic;
+    }
+
+    public static void switchOrder(Category category1, Category category2) {
+        long order = category1.getCategoryOrder();
+        category1.categoryOrder = category2.getCategoryOrder();
+        category2.categoryOrder = order;
+    }
 }

--- a/src/main/java/site/caboomlog/backendservice/category/exception/CategoryNotFoundException.java
+++ b/src/main/java/site/caboomlog/backendservice/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,11 @@
+package site.caboomlog.backendservice.category.exception;
+
+public class CategoryNotFoundException extends RuntimeException {
+    public CategoryNotFoundException(String message) {
+        super(message);
+    }
+
+    public CategoryNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/site/caboomlog/backendservice/category/repository/CategoryRepository.java
+++ b/src/main/java/site/caboomlog/backendservice/category/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package site.caboomlog.backendservice.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.caboomlog.backendservice.category.entity.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    long countByBlog_BlogFidAndParentCategory(String blogFid, Category parent);
+}

--- a/src/main/java/site/caboomlog/backendservice/category/repository/CategoryRepository.java
+++ b/src/main/java/site/caboomlog/backendservice/category/repository/CategoryRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    long countByBlog_BlogFidAndParentCategory(String blogFid, Category parent);
+    int countByBlog_BlogFidAndParentCategory(String blogFid, Category parent);
 
     @Query("SELECT c FROM Category c JOIN FETCH c.topic WHERE c.blog.blogFid = ?1 ORDER BY c.categoryOrder ASC")
     List<Category> findAllByBlog_BlogFid(String blogFid);

--- a/src/main/java/site/caboomlog/backendservice/category/repository/CategoryRepository.java
+++ b/src/main/java/site/caboomlog/backendservice/category/repository/CategoryRepository.java
@@ -1,8 +1,17 @@
 package site.caboomlog.backendservice.category.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import site.caboomlog.backendservice.category.entity.Category;
+
+import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     long countByBlog_BlogFidAndParentCategory(String blogFid, Category parent);
+
+    @Query("SELECT c FROM Category c JOIN FETCH c.topic WHERE c.blog.blogFid = ?1 ORDER BY c.categoryOrder ASC")
+    List<Category> findAllByBlog_BlogFid(String blogFid);
+
+    @Query("SELECT c FROM Category c JOIN FETCH c.topic WHERE c.blog.blogFid = ?1 AND c.categoryPublic = true ORDER BY c.categoryOrder ASC")
+    List<Category> findAllPublicByBlog_BlogFid(String blogFid);
 }

--- a/src/main/java/site/caboomlog/backendservice/category/repository/CategoryRepository.java
+++ b/src/main/java/site/caboomlog/backendservice/category/repository/CategoryRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import site.caboomlog.backendservice.category.entity.Category;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     long countByBlog_BlogFidAndParentCategory(String blogFid, Category parent);
@@ -14,4 +15,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     @Query("SELECT c FROM Category c JOIN FETCH c.topic WHERE c.blog.blogFid = ?1 AND c.categoryPublic = true ORDER BY c.categoryOrder ASC")
     List<Category> findAllPublicByBlog_BlogFid(String blogFid);
+
+    @Query("SELECT c FROM Category c JOIN FETCH c.blog WHERE c.categoryId = ?1")
+    Optional<Category> findByCategoryId(long categoryId);
+
 }

--- a/src/main/java/site/caboomlog/backendservice/category/repository/CategoryRepository.java
+++ b/src/main/java/site/caboomlog/backendservice/category/repository/CategoryRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     int countByBlog_BlogFidAndParentCategory(String blogFid, Category parent);
 
+    int countByBlog_BlogFid(String blogFid);
+
     @Query("SELECT c FROM Category c JOIN FETCH c.topic WHERE c.blog.blogFid = ?1 ORDER BY c.categoryOrder ASC")
     List<Category> findAllByBlog_BlogFid(String blogFid);
 

--- a/src/main/java/site/caboomlog/backendservice/category/service/CategoryService.java
+++ b/src/main/java/site/caboomlog/backendservice/category/service/CategoryService.java
@@ -57,8 +57,8 @@ public class CategoryService {
         }
         Topic topic = optionalTopic.get();
 
-        long newCategoryOrder = 0;
-        long depth = 1;
+        int newCategoryOrder = 0;
+        int depth = 1;
         Category parent = null;
 
         if (request.getCategoryPid() != null) {

--- a/src/main/java/site/caboomlog/backendservice/category/service/CategoryService.java
+++ b/src/main/java/site/caboomlog/backendservice/category/service/CategoryService.java
@@ -1,0 +1,65 @@
+package site.caboomlog.backendservice.category.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.caboomlog.backendservice.blog.entity.Blog;
+import site.caboomlog.backendservice.blogmember.entity.BlogMemberMapping;
+import site.caboomlog.backendservice.blogmember.repository.BlogMemberMappingRepository;
+import site.caboomlog.backendservice.category.dto.CreateCategoryRequest;
+import site.caboomlog.backendservice.category.entity.Category;
+import site.caboomlog.backendservice.category.repository.CategoryRepository;
+import site.caboomlog.backendservice.common.exception.BadRequestException;
+import site.caboomlog.backendservice.common.exception.UnauthenticatedException;
+import site.caboomlog.backendservice.topic.entity.Topic;
+import site.caboomlog.backendservice.topic.exception.TopicNotFoundException;
+import site.caboomlog.backendservice.topic.repository.TopicRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final BlogMemberMappingRepository blogMemberMappingRepository;
+    private final TopicRepository topicRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public void createCategory(String blogFid, Long mbNo, CreateCategoryRequest request) {
+
+        BlogMemberMapping ownerMapping = blogMemberMappingRepository.findByMember_MbNoAndBlog_BlogFid(mbNo, blogFid);
+        if (!"ROLE_OWNER".equalsIgnoreCase(ownerMapping.getRole().getRoleId())) {
+            throw new UnauthenticatedException("블로그 소유자가 아닙니다.");
+        }
+        Blog blog = ownerMapping.getBlog();
+
+        Optional<Topic> optionalTopic = topicRepository.findById(request.getTopicId());
+        if (optionalTopic.isEmpty()) {
+            throw new TopicNotFoundException("토픽을 찾을 수 없습니다.");
+        }
+        Topic topic = optionalTopic.get();
+
+        Category parent = null;
+        long newCategoryOrder = 0;
+        long depth = 1;
+        Optional<Category> optionalParent = categoryRepository.findById(request.getCategoryPid());
+        if (optionalParent.isPresent()) {
+            parent = optionalParent.get();
+            if (parent.getDepth() >= 5) {
+                throw new BadRequestException("카테고리 depth는 최대 5까지만 가능합니다.");
+            }
+            newCategoryOrder = parent.getChildCategories().size() + 1;
+            depth += parent.getDepth();
+        } else {
+            newCategoryOrder = categoryRepository.countByBlog_BlogFidAndParentCategory(blogFid, null) + 1;
+        }
+
+        Category newCategory = Category.ofNewCategory(blog, parent, topic,
+                request.getCategoryName(), request.isCategoryPublic(), newCategoryOrder,
+                depth);
+        categoryRepository.save(newCategory);
+    }
+
+
+}

--- a/src/main/java/site/caboomlog/backendservice/category/service/CategoryService.java
+++ b/src/main/java/site/caboomlog/backendservice/category/service/CategoryService.java
@@ -133,13 +133,13 @@ public class CategoryService {
      * @param mbNo        로그인한 사용자(블로그 소유자)의 회원 번호
      * @param blogFid     블로그 식별자
      * @param categoryId  공개 여부를 변경할 카테고리 ID
-     * @param blogPublic  true: 공개, false: 비공개
+     * @param categoryPublic  true: 공개, false: 비공개
      * @throws UnauthenticatedException 사용자가 블로그 소유자가 아닐 경우
      * @throws CategoryNotFoundException 카테고리가 존재하지 않을 경우
      * @throws BadRequestException 카테고리가 해당 블로그에 속하지 않은 경우
      */
     @Transactional
-    public void changeVisibility(Long mbNo, String blogFid, Long categoryId, boolean blogPublic) {
+    public void changeVisibility(Long mbNo, String blogFid, Long categoryId, boolean categoryPublic) {
         BlogMemberMapping ownerMapping = blogMemberMappingRepository.findByMember_MbNoAndBlog_BlogFid(mbNo, blogFid);
         if (!"ROLE_OWNER".equalsIgnoreCase(ownerMapping.getRole().getRoleId())) {
             throw new UnauthenticatedException("블로그 소유자가 아닙니다.");
@@ -149,14 +149,14 @@ public class CategoryService {
         if (!blogFid.equals(category.getBlog().getBlogFid())) {
             throw new BadRequestException("카테고리가 해당 블로그 소속이 아닙니다.");
         }
-        if (blogPublic) {
-            category.changeVisibility(blogPublic);
+        if (categoryPublic) {
+            category.changeVisibility(categoryPublic);
             categoryRepository.save(category);
         } else {
             List<Category> categories = categoryRepository.findAllByBlog_BlogFid(blogFid);
             List<Category> children = collectChildren(category, categories);
             for (Category c : children) {
-                c.changeVisibility(blogPublic);
+                c.changeVisibility(categoryPublic);
                 categoryRepository.save(c);
             }
         }

--- a/src/main/java/site/caboomlog/backendservice/category/service/CategoryService.java
+++ b/src/main/java/site/caboomlog/backendservice/category/service/CategoryService.java
@@ -57,6 +57,10 @@ public class CategoryService {
         }
         Topic topic = optionalTopic.get();
 
+        if (categoryRepository.countByBlog_BlogFid(blogFid) >= 200) {
+            throw new BadRequestException("카테고리는 최대 200개까지만 생성 가능합니다.");
+        }
+
         int newCategoryOrder = 0;
         int depth = 1;
         Category parent = null;

--- a/src/main/java/site/caboomlog/backendservice/category/service/CategoryService.java
+++ b/src/main/java/site/caboomlog/backendservice/category/service/CategoryService.java
@@ -6,8 +6,10 @@ import org.springframework.transaction.annotation.Transactional;
 import site.caboomlog.backendservice.blog.entity.Blog;
 import site.caboomlog.backendservice.blogmember.entity.BlogMemberMapping;
 import site.caboomlog.backendservice.blogmember.repository.BlogMemberMappingRepository;
+import site.caboomlog.backendservice.category.dto.CategoryResponse;
 import site.caboomlog.backendservice.category.dto.CreateCategoryRequest;
 import site.caboomlog.backendservice.category.entity.Category;
+import site.caboomlog.backendservice.category.exception.CategoryNotFoundException;
 import site.caboomlog.backendservice.category.repository.CategoryRepository;
 import site.caboomlog.backendservice.common.exception.BadRequestException;
 import site.caboomlog.backendservice.common.exception.UnauthenticatedException;
@@ -15,7 +17,7 @@ import site.caboomlog.backendservice.topic.entity.Topic;
 import site.caboomlog.backendservice.topic.exception.TopicNotFoundException;
 import site.caboomlog.backendservice.topic.repository.TopicRepository;
 
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +27,21 @@ public class CategoryService {
     private final TopicRepository topicRepository;
     private final CategoryRepository categoryRepository;
 
+    /**
+     * 블로그에 새로운 카테고리를 생성합니다.
+     * <p>
+     * 블로그 소유자만 카테고리를 등록할 수 있으며,
+     * 루트 카테고리 또는 최대 5단계까지의 하위 카테고리를 생성할 수 있습니다.
+     * </p>
+     *
+     * @param blogFid 블로그 식별자
+     * @param mbNo    로그인한 사용자의 회원 번호
+     * @param request 카테고리 생성 요청 정보
+     * @throws UnauthenticatedException   사용자가 블로그 소유자가 아닐 경우
+     * @throws TopicNotFoundException     요청한 토픽이 존재하지 않을 경우
+     * @throws CategoryNotFoundException  상위 카테고리가 존재하지 않을 경우
+     * @throws BadRequestException        상위 카테고리 depth 초과 또는 비공개 하위 등록 시
+     */
     @Transactional
     public void createCategory(String blogFid, Long mbNo, CreateCategoryRequest request) {
 
@@ -40,14 +57,18 @@ public class CategoryService {
         }
         Topic topic = optionalTopic.get();
 
-        Category parent = null;
         long newCategoryOrder = 0;
         long depth = 1;
-        Optional<Category> optionalParent = categoryRepository.findById(request.getCategoryPid());
-        if (optionalParent.isPresent()) {
-            parent = optionalParent.get();
+        Category parent = null;
+
+        if (request.getCategoryPid() != null) {
+            parent = categoryRepository.findById(request.getCategoryPid())
+                    .orElseThrow(()->new CategoryNotFoundException("상위 카테고리가 존재하지 않습니다."));
             if (parent.getDepth() >= 5) {
                 throw new BadRequestException("카테고리 depth는 최대 5까지만 가능합니다.");
+            }
+            if (Boolean.FALSE.equals(parent.getCategoryPublic()) && request.isCategoryPublic()) {
+                throw new BadRequestException("상위 카테고리가 비공개 카테고리입니다. 비공개 카테고리 하위에 공개 카테고리를 등록할 수 없습니다.");
             }
             newCategoryOrder = parent.getChildCategories().size() + 1;
             depth += parent.getDepth();
@@ -61,5 +82,75 @@ public class CategoryService {
         categoryRepository.save(newCategory);
     }
 
+    /**
+     * 블로그의 모든 카테고리를 트리 형태로 조회합니다.
+     * <p>
+     * 블로그 소유자만 조회할 수 있으며, 루트 카테고리부터 하위 카테고리까지 포함됩니다.
+     * </p>
+     *
+     * @param blogFid 블로그 식별자
+     * @param mbNo    로그인한 사용자의 회원 번호
+     * @return 트리 구조의 전체 카테고리 목록
+     * @throws UnauthenticatedException 사용자가 블로그 소유자가 아닐 경우
+     */
+    @Transactional(readOnly = true)
+    public List<CategoryResponse> getCategories(String blogFid, Long mbNo) {
+        BlogMemberMapping ownerMapping = blogMemberMappingRepository.findByMember_MbNoAndBlog_BlogFid(mbNo, blogFid);
+        if (!"ROLE_OWNER".equalsIgnoreCase(ownerMapping.getRole().getRoleId())) {
+            throw new UnauthenticatedException("블로그 소유자가 아닙니다.");
+        }
+
+        List<Category> categories = categoryRepository.findAllByBlog_BlogFid(blogFid);
+
+        return buildCategoryTree(categories);
+    }
+
+    /**
+     * 블로그의 공개된 카테고리만 트리 구조로 조회합니다.
+     * <p>
+     * 인증 없이 누구나 접근 가능한 API를 위한 메서드입니다.
+     * </p>
+     *
+     * @param blogFid 블로그 식별자
+     * @return 트리 구조의 공개된 카테고리 목록
+     */
+    @Transactional(readOnly = true)
+    public List<CategoryResponse> getAllPublicCategories(String blogFid) {
+
+        List<Category> categories = categoryRepository.findAllPublicByBlog_BlogFid(blogFid);
+
+        return buildCategoryTree(categories);
+    }
+
+    /**
+     * 카테고리 목록을 트리 구조로 변환합니다.
+     * <p>
+     * 부모-자식 관계를 기반으로 트리를 구성하며,
+     * 부모가 없는 루트 카테고리부터 하위 카테고리를 연결합니다.
+     * </p>
+     *
+     * @param categories 평면 구조의 카테고리 목록
+     * @return 트리 구조로 구성된 카테고리 응답 목록
+     */
+    private List<CategoryResponse> buildCategoryTree(List<Category> categories) {
+        Map<Long, CategoryResponse> map = new LinkedHashMap<>();
+        List<CategoryResponse> rootList = new ArrayList<>();
+
+        for (Category category : categories) {
+            CategoryResponse dto = new CategoryResponse(category);
+            map.put(category.getCategoryId(), dto);
+        }
+
+        for (Category category : categories) {
+            CategoryResponse current = map.get(category.getCategoryId());
+            if (category.getParentCategory() != null) {
+                CategoryResponse parent = map.get(category.getParentCategory().getCategoryId());
+                parent.getChildren().add(current);
+            } else {
+                rootList.add(current);
+            }
+        }
+        return rootList;
+    }
 
 }

--- a/src/main/java/site/caboomlog/backendservice/common/interceptor/AuthHeaderInterceptor.java
+++ b/src/main/java/site/caboomlog/backendservice/common/interceptor/AuthHeaderInterceptor.java
@@ -13,10 +13,12 @@ public class AuthHeaderInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String uri = request.getRequestURI();
         if (request.getMethod().equalsIgnoreCase("GET") &&
-                (request.getRequestURI().matches("/api/blogs/[^/]+$") ||
-                    request.getRequestURI().matches("/api/blogs/[^/]+/members") ||
-                    request.getRequestURI().matches("/api/topics"))
+                (uri.matches("/api/blogs/[^/]+$") ||
+                uri.matches("/api/blogs/[^/]+/members") ||
+                uri.matches("/api/topics") ||
+                uri.matches("/api/blogs/[^/]+/categories/public"))
         ) {
             return true;
         }

--- a/src/main/java/site/caboomlog/backendservice/topic/advice/TopicControllerAdvice.java
+++ b/src/main/java/site/caboomlog/backendservice/topic/advice/TopicControllerAdvice.java
@@ -1,0 +1,19 @@
+package site.caboomlog.backendservice.topic.advice;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import site.caboomlog.backendservice.common.dto.ApiResponse;
+import site.caboomlog.backendservice.topic.exception.TopicNotFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class TopicControllerAdvice {
+    @ExceptionHandler(TopicNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTopicNotFoundException(TopicNotFoundException e) {
+        log.info("handleTopicNotFoundException - ", e);
+        return ResponseEntity.status(404)
+                .body(ApiResponse.notFound(e.getMessage()));
+    }
+}

--- a/src/main/java/site/caboomlog/backendservice/topic/exception/TopicNotFoundException.java
+++ b/src/main/java/site/caboomlog/backendservice/topic/exception/TopicNotFoundException.java
@@ -1,0 +1,11 @@
+package site.caboomlog.backendservice.topic.exception;
+
+public class TopicNotFoundException extends RuntimeException {
+    public TopicNotFoundException(String message) {
+        super(message);
+    }
+
+    public TopicNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/site/caboomlog/backendservice/category/controller/CategoryControllerTest.java
+++ b/src/test/java/site/caboomlog/backendservice/category/controller/CategoryControllerTest.java
@@ -154,11 +154,11 @@ class CategoryControllerTest {
     }
 
     @Test
-    @DisplayName("카테고리 등록 실패 - 최대 depth 초과 or 비공개 카테고리 하위에 공개카테고리 등록 시도")
+    @DisplayName("카테고리 등록 실패 - 최대 depth 초과 or 비공개 카테고리 하위에 공개카테고리 등록 시도 or 카테고리 최대 갯수 초과")
     void createCategoryFail_DepthIsMax() throws Exception {
         // given
         Mockito.when(memberRepository.findByMbUuid(anyString())).thenReturn(Optional.of(testMember));
-        Mockito.doThrow(new BadRequestException("depth는 최대 5까지만 가능합니다"))
+        Mockito.doThrow(new BadRequestException("잘못된 요청"))
                 .when(categoryService).createCategory(anyString(), anyLong(), any());
 
         // when & then

--- a/src/test/java/site/caboomlog/backendservice/category/controller/CategoryControllerTest.java
+++ b/src/test/java/site/caboomlog/backendservice/category/controller/CategoryControllerTest.java
@@ -243,11 +243,11 @@ class CategoryControllerTest {
     void getAllCategoriesSuccess() throws Exception {
         // given
         Category rootCategory1 = Category.ofNewCategory(testBlog, null, testTopic,
-                "루트카테고리1", true, 1L, 1L);
+                "루트카테고리1", true, 1, 1);
         Category subCategory1 = Category.ofNewCategory(testBlog, rootCategory1, testTopic,
-                "서브카테고리1", false, 1L, 2L);
+                "서브카테고리1", false, 1, 2);
         Category subCategory2 = Category.ofNewCategory(testBlog, rootCategory1, testTopic,
-                "서브카테고리2", true, 2L, 2L);
+                "서브카테고리2", true, 2, 2);
 
         CategoryResponse root = new CategoryResponse(rootCategory1);
         root.getChildren().add(new CategoryResponse(subCategory1));
@@ -276,11 +276,11 @@ class CategoryControllerTest {
     void getAllPublicCategories() throws Exception {
         // given
         Category rootCategory1 = Category.ofNewCategory(testBlog, null, testTopic,
-                "루트카테고리1", true, 1L, 1L);
+                "루트카테고리1", true, 1, 1);
         Category subPrivateCategory = Category.ofNewCategory(testBlog, rootCategory1, testTopic,
-                "서브카테고리1", false, 1L, 2L);
+                "서브카테고리1", false, 1, 2);
         Category subPublicCategory = Category.ofNewCategory(testBlog, rootCategory1, testTopic,
-                "서브카테고리2", true, 2L, 2L);
+                "서브카테고리2", true, 2, 2);
         CategoryResponse root = new CategoryResponse(rootCategory1);
         root.getChildren().add(new CategoryResponse(subPublicCategory));
 

--- a/src/test/java/site/caboomlog/backendservice/category/controller/CategoryControllerTest.java
+++ b/src/test/java/site/caboomlog/backendservice/category/controller/CategoryControllerTest.java
@@ -312,7 +312,7 @@ class CategoryControllerTest {
         mockMvc.perform(post("/api/blogs/caboom/categories/1/public")
                 .header("X-Caboomlog-UID", UUID.randomUUID().toString())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"blogPublic\" : true}"))
+                .content("{\"categoryPublic\" : true}"))
                 .andDo(print())
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.status").value("ERROR"));
@@ -330,7 +330,7 @@ class CategoryControllerTest {
         mockMvc.perform(post("/api/blogs/caboom/categories/1/public")
                         .header("X-Caboomlog-UID", UUID.randomUUID().toString())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"blogPublic\" : true}"))
+                        .content("{\"categoryPublic\" : true}"))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value("ERROR"));
@@ -348,7 +348,7 @@ class CategoryControllerTest {
         mockMvc.perform(post("/api/blogs/caboom/categories/1/public")
                         .header("X-Caboomlog-UID", UUID.randomUUID().toString())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"blogPublic\" : true}"))
+                        .content("{\"categoryPublic\" : true}"))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value("ERROR"));
@@ -366,7 +366,7 @@ class CategoryControllerTest {
         mockMvc.perform(post("/api/blogs/caboom/categories/1/public")
                         .header("X-Caboomlog-UID", UUID.randomUUID().toString())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"blogPublic\" : true}"))
+                        .content("{\"categoryPublic\" : true}"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"));

--- a/src/test/java/site/caboomlog/backendservice/category/controller/CategoryControllerTest.java
+++ b/src/test/java/site/caboomlog/backendservice/category/controller/CategoryControllerTest.java
@@ -13,7 +13,11 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import site.caboomlog.backendservice.blog.entity.Blog;
+import site.caboomlog.backendservice.blog.entity.BlogType;
 import site.caboomlog.backendservice.category.advice.CategoryControllerAdvice;
+import site.caboomlog.backendservice.category.dto.CategoryResponse;
+import site.caboomlog.backendservice.category.entity.Category;
 import site.caboomlog.backendservice.category.service.CategoryService;
 import site.caboomlog.backendservice.common.advice.CommonControllerAdvice;
 import site.caboomlog.backendservice.common.annotation.LoginMemberArgumentResolver;
@@ -23,12 +27,16 @@ import site.caboomlog.backendservice.common.interceptor.AuthHeaderInterceptor;
 import site.caboomlog.backendservice.member.entity.Member;
 import site.caboomlog.backendservice.member.repository.MemberRepository;
 import site.caboomlog.backendservice.topic.advice.TopicControllerAdvice;
+import site.caboomlog.backendservice.topic.entity.Topic;
 import site.caboomlog.backendservice.topic.exception.TopicNotFoundException;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -53,6 +61,10 @@ class CategoryControllerTest {
             1L, "caboom@test.com", "카붐", "1234qwer",
             "010-0000-1111", null, null
     );
+    Blog testBlog = Blog.ofExistingBlog(1L, "caboom", true, "카붐로그",
+            "안녕하세요", true, null, BlogType.PERSONAL);
+    Topic testTopic = Topic.ofExsitingTopic(1, null, "루트 테스트 토픽", 1,
+            null, null);
 
     @TestConfiguration
     static class MockConfig {
@@ -79,8 +91,15 @@ class CategoryControllerTest {
                 .standaloneSetup(new CategoryController(categoryService))
                 .setCustomArgumentResolvers(loginMemberArgumentResolver)
                 .addInterceptors(authHeaderInterceptor)
-                .setControllerAdvice(TopicControllerAdvice.class, CategoryControllerAdvice.class, CommonControllerAdvice.class)
+                .setControllerAdvice(TopicControllerAdvice.class,
+                        CategoryControllerAdvice.class,
+                        CommonControllerAdvice.class)
                 .build();
+    }
+
+    @BeforeEach
+    void resetMocks() {
+        Mockito.reset(categoryService);
     }
 
     @Test
@@ -134,7 +153,7 @@ class CategoryControllerTest {
     }
 
     @Test
-    @DisplayName("카테고리 등록 실패 - 최대 depth 초과")
+    @DisplayName("카테고리 등록 실패 - 최대 depth 초과 or 비공개 카테고리 하위에 공개카테고리 등록 시도")
     void createCategoryFail_DepthIsMax() throws Exception {
         // given
         Mockito.when(memberRepository.findByMbUuid(anyString())).thenReturn(Optional.of(testMember));
@@ -181,6 +200,103 @@ class CategoryControllerTest {
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("카테고리 목록 조회 실패 - 소유자 권한 없음")
+    void getAllCategoriesFail_Unauthenticated() throws Exception {
+        // given
+        Mockito.when(memberRepository.findByMbUuid(anyString())).thenReturn(Optional.of(testMember));
+        Mockito.when(categoryService.getCategories(anyString(), anyLong()))
+                .thenThrow(new UnauthenticatedException("블로그 소유자가 아닙니다."));
+
+        // when & then
+        mockMvc.perform(get("/api/blogs/caboom/categories")
+                .header("X-Caboomlog-UID", UUID.randomUUID().toString())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value("ERROR"));
+    }
+
+    @Test
+    @DisplayName("카테고리 목록 조회 성공 - 카테고리가 없을 때")
+    void getAllCategoriesSuccess_Empty() throws Exception {
+        // given
+        Mockito.when(memberRepository.findByMbUuid(anyString())).thenReturn(Optional.of(testMember));
+        Mockito.when(categoryService.getCategories(anyString(), anyLong()))
+                .thenReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/api/blogs/caboom/categories")
+                        .header("X-Caboomlog-UID", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.content").isEmpty());
+    }
+
+    @Test
+    @DisplayName("카테고리 목록 조회 성공")
+    void getAllCategoriesSuccess() throws Exception {
+        // given
+        Category rootCategory1 = Category.ofNewCategory(testBlog, null, testTopic,
+                "루트카테고리1", true, 1L, 1L);
+        Category subCategory1 = Category.ofNewCategory(testBlog, rootCategory1, testTopic,
+                "서브카테고리1", false, 1L, 2L);
+        Category subCategory2 = Category.ofNewCategory(testBlog, rootCategory1, testTopic,
+                "서브카테고리2", true, 2L, 2L);
+
+        CategoryResponse root = new CategoryResponse(rootCategory1);
+        root.getChildren().add(new CategoryResponse(subCategory1));
+        root.getChildren().add(new CategoryResponse(subCategory2));
+
+        Mockito.when(memberRepository.findByMbUuid(anyString())).thenReturn(Optional.of(testMember));
+        Mockito.when(categoryService.getCategories(anyString(), anyLong()))
+                .thenReturn(List.of(
+                        root
+                ));
+
+        // when & then
+        mockMvc.perform(get("/api/blogs/caboom/categories")
+                        .header("X-Caboomlog-UID", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].categoryName").value(rootCategory1.getCategoryName()))
+                .andExpect(jsonPath("$.content[0].children", hasSize(2)));
+    }
+
+    @Test
+    @DisplayName("공개 카테고리 목록 조회 성공")
+    void getAllPublicCategories() throws Exception {
+        // given
+        Category rootCategory1 = Category.ofNewCategory(testBlog, null, testTopic,
+                "루트카테고리1", true, 1L, 1L);
+        Category subPrivateCategory = Category.ofNewCategory(testBlog, rootCategory1, testTopic,
+                "서브카테고리1", false, 1L, 2L);
+        Category subPublicCategory = Category.ofNewCategory(testBlog, rootCategory1, testTopic,
+                "서브카테고리2", true, 2L, 2L);
+        CategoryResponse root = new CategoryResponse(rootCategory1);
+        root.getChildren().add(new CategoryResponse(subPublicCategory));
+
+        Mockito.when(memberRepository.findByMbUuid(anyString())).thenReturn(Optional.of(testMember));
+        Mockito.when(categoryService.getAllPublicCategories(anyString()))
+                .thenReturn(List.of(root));
+
+        // when & then
+        mockMvc.perform(get("/api/blogs/caboom/categories/public")
+                        .header("X-Caboomlog-UID", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].categoryName").value(rootCategory1.getCategoryName()))
+                .andExpect(jsonPath("$.content[0].children", hasSize(1)));
     }
 
 }

--- a/src/test/java/site/caboomlog/backendservice/category/controller/CategoryControllerTest.java
+++ b/src/test/java/site/caboomlog/backendservice/category/controller/CategoryControllerTest.java
@@ -1,0 +1,186 @@
+package site.caboomlog.backendservice.category.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import site.caboomlog.backendservice.category.advice.CategoryControllerAdvice;
+import site.caboomlog.backendservice.category.service.CategoryService;
+import site.caboomlog.backendservice.common.advice.CommonControllerAdvice;
+import site.caboomlog.backendservice.common.annotation.LoginMemberArgumentResolver;
+import site.caboomlog.backendservice.common.exception.BadRequestException;
+import site.caboomlog.backendservice.common.exception.UnauthenticatedException;
+import site.caboomlog.backendservice.common.interceptor.AuthHeaderInterceptor;
+import site.caboomlog.backendservice.member.entity.Member;
+import site.caboomlog.backendservice.member.repository.MemberRepository;
+import site.caboomlog.backendservice.topic.advice.TopicControllerAdvice;
+import site.caboomlog.backendservice.topic.exception.TopicNotFoundException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CategoryController.class)
+@Import(CategoryControllerTest.MockConfig.class)
+class CategoryControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    CategoryService categoryService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    Member testMember = Member.ofExistingMember(
+            1L, "caboom@test.com", "카붐", "1234qwer",
+            "010-0000-1111", null, null
+    );
+
+    @TestConfiguration
+    static class MockConfig {
+        @Bean
+        public CategoryService categoryService() {
+            return Mockito.mock(CategoryService.class);
+        }
+
+        @Bean
+        public MemberRepository memberRepository() {
+            return Mockito.mock(MemberRepository.class);
+        }
+
+        @Bean
+        public AuthHeaderInterceptor authHeaderInterceptor() {
+            return new AuthHeaderInterceptor();
+        }
+    }
+
+    @BeforeEach
+    void setup(@Autowired HandlerMethodArgumentResolver loginMemberArgumentResolver,
+               @Autowired AuthHeaderInterceptor authHeaderInterceptor) {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new CategoryController(categoryService))
+                .setCustomArgumentResolvers(loginMemberArgumentResolver)
+                .addInterceptors(authHeaderInterceptor)
+                .setControllerAdvice(TopicControllerAdvice.class, CategoryControllerAdvice.class, CommonControllerAdvice.class)
+                .build();
+    }
+
+    @Test
+    @DisplayName("카테고리 등록 실패 - 토픽 없음")
+    void createCategoryFail_TopicNotFound() throws Exception {
+        // given
+        Mockito.when(memberRepository.findByMbUuid(anyString())).thenReturn(Optional.of(testMember));
+        Mockito.doThrow(new TopicNotFoundException("토픽을 찾을 수 없습니다"))
+                .when(categoryService).createCategory(anyString(), anyLong(), any());
+
+        // when & then
+        mockMvc.perform(post("/api/blogs/caboom/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Caboomlog-UID", UUID.randomUUID().toString())
+                .content("""
+                {
+                "categoryPid" : 1,
+                "categoryName" : "공부",
+                "topicId" : 11,
+                "categoryPublic" : true
+                }
+                """))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("ERROR"));
+    }
+
+    @Test
+    @DisplayName("카테고리 등록 실패 - 블로그 소유자 아님")
+    void createCategoryFail_Unauthenticated() throws Exception {
+        // given
+        Mockito.when(memberRepository.findByMbUuid(anyString())).thenReturn(Optional.of(testMember));
+        Mockito.doThrow(new UnauthenticatedException("블로그 소유자가 아닙니다"))
+                .when(categoryService).createCategory(anyString(), anyLong(), any());
+
+        // when & then
+        mockMvc.perform(post("/api/blogs/caboom/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Caboomlog-UID", UUID.randomUUID().toString())
+                        .content("""
+                {
+                "categoryPid" : 1,
+                "categoryName" : "공부",
+                "topicId" : 11,
+                "categoryPublic" : true
+                }
+                """))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value("ERROR"));
+    }
+
+    @Test
+    @DisplayName("카테고리 등록 실패 - 최대 depth 초과")
+    void createCategoryFail_DepthIsMax() throws Exception {
+        // given
+        Mockito.when(memberRepository.findByMbUuid(anyString())).thenReturn(Optional.of(testMember));
+        Mockito.doThrow(new BadRequestException("depth는 최대 5까지만 가능합니다"))
+                .when(categoryService).createCategory(anyString(), anyLong(), any());
+
+        // when & then
+        mockMvc.perform(post("/api/blogs/caboom/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Caboomlog-UID", UUID.randomUUID().toString())
+                        .content("""
+                {
+                "categoryPid" : 1,
+                "categoryName" : "공부",
+                "topicId" : 11,
+                "categoryPublic" : true
+                }
+                """))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("ERROR"));
+    }
+
+    @Test
+    @DisplayName("카테고리 등록 성공")
+    void createCategorySuccess() throws Exception {
+        // given
+        Mockito.when(memberRepository.findByMbUuid(anyString())).thenReturn(Optional.of(testMember));
+        Mockito.doNothing()
+                .when(categoryService).createCategory(anyString(), anyLong(), any());
+
+        // when & then
+        mockMvc.perform(post("/api/blogs/caboom/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-Caboomlog-UID", UUID.randomUUID().toString())
+                        .content("""
+                {
+                "categoryPid" : 1,
+                "categoryName" : "공부",
+                "topicId" : 11,
+                "categoryPublic" : true
+                }
+                """))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("SUCCESS"));
+    }
+
+}

--- a/src/test/java/site/caboomlog/backendservice/category/service/CategoryServiceTest.java
+++ b/src/test/java/site/caboomlog/backendservice/category/service/CategoryServiceTest.java
@@ -182,6 +182,34 @@ class CategoryServiceTest {
     }
 
     @Test
+    @DisplayName("카테고리 등록 실패 - 카테고리 최대 갯수 초과")
+    void createCategoryFail_MaxCountOver() throws Exception {
+        // given
+        Constructor<CreateCategoryRequest> categoryRequestAllArgsConstructor =
+                CreateCategoryRequest.class.getDeclaredConstructor();
+        categoryRequestAllArgsConstructor.setAccessible(true);
+        CreateCategoryRequest request = categoryRequestAllArgsConstructor.newInstance();
+
+        categoryNameField.set(request, "루트카테고리");
+        topicIdField.set(request, 1);
+        categoryPublicField.set(request, true);
+        categoryPidField.set(request, 22L);
+
+        Mockito.when(blogMemberMappingRepository
+                        .findByMember_MbNoAndBlog_BlogFid(anyLong(), anyString()))
+                .thenReturn(BlogMemberMapping.ofNewBlogMemberMapping(
+                        testBlog, testMember, roleOwner, "블로그 소유자"
+                ));
+        Mockito.when(topicRepository.findById(anyInt()))
+                .thenReturn(Optional.of(testTopic));
+        Mockito.when(categoryRepository.countByBlog_BlogFid(anyString())).thenReturn(200);
+
+        // when & then
+        Assertions.assertThrows(BadRequestException.class,
+                () -> categoryService.createCategory("caboom", 1L, request));
+    }
+
+    @Test
     @DisplayName("상위 카테고리가 private이고 등록할 하위 카테고리가 public이면 BadRequest")
     void createCaetgoryFail_CreatePublicUnderPrivate() throws Exception {
         // given

--- a/src/test/java/site/caboomlog/backendservice/category/service/CategoryServiceTest.java
+++ b/src/test/java/site/caboomlog/backendservice/category/service/CategoryServiceTest.java
@@ -173,7 +173,7 @@ class CategoryServiceTest {
         Mockito.when(categoryRepository.findById(anyLong()))
                 .thenReturn(Optional.of(
                         Category.ofNewCategory(testBlog, null, testTopic, "depth5인 카테고리",
-                                true, 1L, 5L)
+                                true, 1, 5)
                 ));
 
         // when & then
@@ -205,7 +205,7 @@ class CategoryServiceTest {
         Mockito.when(categoryRepository.findById(anyLong()))
                 .thenReturn(Optional.of(
                         Category.ofNewCategory(testBlog, null, testTopic, "depth5인 카테고리",
-                                false, 1L, 5L)
+                                false, 1, 5)
                 ));
 
         // when & then
@@ -234,7 +234,7 @@ class CategoryServiceTest {
         Mockito.when(topicRepository.findById(anyInt()))
                 .thenReturn(Optional.of(testTopic));
         Mockito.when(categoryRepository.countByBlog_BlogFidAndParentCategory(anyString(), any()))
-                .thenReturn(3L);
+                .thenReturn(3);
 
         // when
         categoryService.createCategory("caboom", 1L, request);
@@ -244,8 +244,8 @@ class CategoryServiceTest {
         Category saved = categoryCaptor.getValue();
 
         Assertions.assertEquals("루트카테고리", saved.getCategoryName());
-        Assertions.assertEquals(4L, saved.getCategoryOrder());
-        Assertions.assertEquals(1L, saved.getDepth());
+        Assertions.assertEquals(4, saved.getCategoryOrder());
+        Assertions.assertEquals(1, saved.getDepth());
         Assertions.assertNull(saved.getParentCategory());
         Assertions.assertTrue(saved.getCategoryPublic());
     }
@@ -259,7 +259,7 @@ class CategoryServiceTest {
         categoryRequestAllArgsConstructor.setAccessible(true);
         CreateCategoryRequest request = categoryRequestAllArgsConstructor.newInstance();
         Category parent = Category.ofNewCategory(testBlog, null, testTopic, "부모",
-                true, 1L, 2L);
+                true, 1, 2);
 
         categoryNameField.set(request, "서브카테고리");
         topicIdField.set(request, 1);
@@ -284,8 +284,8 @@ class CategoryServiceTest {
         Category saved = categoryCaptor.getValue();
 
         Assertions.assertEquals("서브카테고리", saved.getCategoryName());
-        Assertions.assertEquals(1L, saved.getCategoryOrder());
-        Assertions.assertEquals(3L, saved.getDepth());
+        Assertions.assertEquals(1, saved.getCategoryOrder());
+        Assertions.assertEquals(3, saved.getDepth());
         Assertions.assertEquals(parent, saved.getParentCategory());
         Assertions.assertTrue(saved.getCategoryPublic());
     }
@@ -315,7 +315,7 @@ class CategoryServiceTest {
         Mockito.when(categoryRepository.findAllByBlog_BlogFid(anyString()))
                 .thenReturn(List.of(
                         Category.ofNewCategory(testBlog, null, testTopic,
-                                "root", true, 1L, 1L)
+                                "root", true, 1, 1)
         ));
         // when
         List<CategoryResponse> response = categoryService.getCategories("caboom", 2L);
@@ -329,16 +329,16 @@ class CategoryServiceTest {
     void getPublicCategoriesSuccess() throws Exception {
         // given
         Category root1 = Category.ofNewCategory(testBlog, null, testTopic,
-                "루트1", true, 1L, 1L);
+                "루트1", true, 1, 1);
         Category root2 = Category.ofNewCategory(testBlog, null, testTopic,
-                "루트2", true, 2L, 1L);
+                "루트2", true, 2, 1);
 
         Category sub1_1 = Category.ofNewCategory(testBlog, root1, testTopic,
-                "서브1-1", true, 1L, 2L);
+                "서브1-1", true, 1, 2);
         Category sub1_2 = Category.ofNewCategory(testBlog, root1, testTopic,
-                "서브1-2", true, 2L, 2L);
+                "서브1-2", true, 2, 2);
         Category sub2_1 = Category.ofNewCategory(testBlog, root2, testTopic,
-                "서브2-1", true, 1L, 2L);
+                "서브2-1", true, 1, 2);
 
         Field categoryIdField = Category.class.getDeclaredField("categoryId");
         categoryIdField.setAccessible(true);
@@ -395,7 +395,7 @@ class CategoryServiceTest {
                         Blog.ofNewBlog("다른블로그", true, "다른블로그", null,
                                 false, BlogType.PERSONAL),
                         null, testTopic, "카테고리!", true,
-                        1L, 1L)));
+                        1, 1)));
 
         // when & then
         Assertions.assertThrows(BadRequestException.class,
@@ -410,7 +410,7 @@ class CategoryServiceTest {
                 .thenReturn(BlogMemberMapping.ofNewBlogMemberMapping(testBlog, testMember, roleOwner, "멤버"));
         Mockito.when(categoryRepository.findByCategoryId(anyLong()))
                 .thenReturn(Optional.of(Category.ofNewCategory(testBlog, null, testTopic,
-                        "카테고리!", false, 1L, 1L)));
+                        "카테고리!", false, 1, 1)));
 
         // when
         categoryService.changeVisibility(1L, "caboom", 1L, true);
@@ -426,11 +426,11 @@ class CategoryServiceTest {
     void changeVisibilitySuccess_childrenPrivate() throws Exception {
         // given
         Category parent = Category.ofNewCategory(testBlog, null, testTopic, "루트1",
-                true, 1L, 1L);
+                true, 1, 1);
         Category child1 = Category.ofNewCategory(testBlog, parent, testTopic, "자식1",
-                true, 1L, 2L);
+                true, 1, 2);
         Category child2 = Category.ofNewCategory(testBlog, parent, testTopic, "자식2",
-                true, 2L, 2L);
+                true, 2, 2);
         Field categoryIdField = Category.class.getDeclaredField("categoryId");
         categoryIdField.setAccessible(true);
         categoryIdField.set(parent, 1L);
@@ -458,11 +458,11 @@ class CategoryServiceTest {
     void changeVisibilitySuccess_parentPublic() throws Exception {
         // given
         Category parent = Category.ofNewCategory(testBlog, null, testTopic, "루트1",
-                false, 1L, 1L);
+                false, 1, 1);
         Category child1 = Category.ofNewCategory(testBlog, parent, testTopic, "자식1",
-                false, 1L, 2L);
+                false, 1, 2);
         Category child2 = Category.ofNewCategory(testBlog, parent, testTopic, "자식2",
-                false, 2L, 2L);
+                false, 2, 2);
         Field categoryIdField = Category.class.getDeclaredField("categoryId");
         categoryIdField.setAccessible(true);
         categoryIdField.set(parent, 1L);


### PR DESCRIPTION
## 구현
- 카테고리 등록 API
    - 블로그당 최대 200개 제한
    - Depth 최대 5로 제한
- 카테고리 목록 조회 API
    - 관리자용 / 비회원용
    - 지정한 순서에 따라 정렬된 트리 형태로 반환
- 카테고리 공개 여부 변경 API
    - private으로 변경할 경우 하위 카테고리들까지 모두 private으로 변경됨
- 카테고리 정렬 순서 변경 API
    - 우선은 같은 depth끼리만 정렬 가능하게 했지만 나중에 변경 가능성 있음

## 테스트
- 단위 테스트: Service / Controller
- 로컬 환경에서 주요 기능 API 정상 작동 확인

## 기타
- 카테고리 삭제 기능은 게시글 연동이 필요해서 나중에 구현하기로 함